### PR TITLE
Add command line util for standalone server

### DIFF
--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -7,6 +7,9 @@ from tornado import web
 from jupyterlab_nvdashboard import apps
 
 
+DEFAULT_PORT = 8000
+
+
 routes = {
     "/GPU-Utilization": apps.gpu.gpu,
     "/GPU-Memory": apps.gpu.gpu_mem,
@@ -23,13 +26,15 @@ class RouteIndex(web.RequestHandler):
     """ A JSON index of all routes present on the Bokeh Server """
 
     def get(self):
-        self.write({route: route.strip("/").replace('-', ' ')
-                    for route in routes})
+        self.write({route: route.strip("/").replace("-", " ") for route in routes})
 
 
 def go():
-    server = Server(routes, port=int(
-        sys.argv[1]), allow_websocket_origin=["*"])
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    else:
+        port = DEFAULT_PORT
+    server = Server(routes, port=port, allow_websocket_origin=["*"])
     server.start()
 
     server._tornado.add_handlers(

--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -27,8 +27,7 @@ class RouteIndex(web.RequestHandler):
                     for route in routes})
 
 
-if __name__ == "__main__":
-
+def go():
     server = Server(routes, port=int(
         sys.argv[1]), allow_websocket_origin=["*"])
     server.start()
@@ -38,3 +37,7 @@ if __name__ == "__main__":
     )
 
     IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    go()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ setuptools.setup(
     entry_points={
         'jupyter_serverproxy_servers': [
             'nvdashboard = jupyterlab_nvdashboard:launch_server',
-        ]
+        ],
+        'console_scripts': [
+            'nvdashboard = jupyterlab_nvdashboard.server:go',
+        ],
     },
     package_data={
         'jupyterlab_nvdashboard': ['icons/*'],


### PR DESCRIPTION
Moved the standalone server startup into a function and then added an entry point so that the function can be invoked with the command `nvdashboard` from the command line.

This should make things easier to run when not using it in Jupyter Lab.