### PR TITLE
Use SPDX `license` metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     description="A JupyterLab extension for displaying dashboards of GPU usage.",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    license="BSD",
+    license="BSD-3-Clause",
     packages=setuptools.find_packages(),
         keywords=['Jupyter'],
         classifiers=['Framework :: Jupyter'],


### PR DESCRIPTION
Follows the naming convention for the license according to SPDX. Makes it easier for users, auditors, and tooling to identify the type of license.