### PR TITLE
Extend startup timeout

### DIFF
--- a/jupyterlab_nvdashboard/__init__.py
+++ b/jupyterlab_nvdashboard/__init__.py
@@ -11,4 +11,4 @@ serverfile = os.path.join(os.path.dirname(__file__), "server.py")
 
 
 def launch_server():
-    return {"command": [sys.executable, serverfile, '{port}']}
+    return {"command": [sys.executable, serverfile, "{port}"], "timeout": 20}


### PR DESCRIPTION
Should fix `could not start nvdashboard in time` error by extending the timeout that Jupyter gives the process to start.

Closes #31 