### PR TITLE
Update npm version in CI

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -60,6 +60,7 @@ python setup.py sdist bdist_wheel
 
 gpuci_logger "Build npm pkg for jupyterlab-nvdashboard"
 gpuci_conda_retry install -y nodejs=10 jupyterlab
+npm i -g npm@latest
 jlpm install
 jlpm build
 


### PR DESCRIPTION
This PR updates the version of `npm` used in CI. This fixes an ambiguous error that was being throw in CI when using `npm version` ([link to error log](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/jupyterlab-nvdashboard/job/branches/job/jupyterlab-nvdashboard-cpu-branch-build/25/console)). Ultimately, it seems that updating to the latest `npm` version make the error go away.

The screenshots below show the results of my local testing and verification for this problem. 

**CI Version. Error**
![image](https://user-images.githubusercontent.com/7400326/114914019-d9197180-9def-11eb-8b02-1a3dd01fe8bd.png)

**Updated Version. No error**
![image](https://user-images.githubusercontent.com/7400326/114915062-17fbf700-9df1-11eb-82f1-cc5c62c5c392.png)
