### PR TITLE
Disabled automatic launcher entry

### DIFF
--- a/jupyterlab_nvdashboard/__init__.py
+++ b/jupyterlab_nvdashboard/__init__.py
@@ -10,7 +10,7 @@ serverfile = os.path.join(os.path.dirname(__file__), "server.py")
 
 
 def launch_server():
-    return {"command": [sys.executable, serverfile, "{port}"], "timeout": 20}
+    return {"command": [sys.executable, serverfile, "{port}"], "timeout": 20, "launcher_entry": {"enabled": False}}
 
 
 def _jupyter_labextension_paths():


### PR DESCRIPTION
Fixes #98. Tested locally. @ian-r-rose 's [comment](https://github.com/rapidsai/jupyterlab-nvdashboard/issues/98#issuecomment-847925377) helped in quickly finding the problem. `jupyterlab-server-proxy` has documentation available on the automatically generated [launcher entry](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html#launcher-entry).