### PR TITLE
Add `nodejs` version specification to conda recipe

### DIFF
--- a/conda/recipes/jupyterlab-nvdashboard/meta.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools
     - pynvml
     - psutil
-    - nodejs
+    - nodejs !=16.10.0
     - jupyter-packaging >=0.7.0,<0.8
   run:
     - python >=3.7
@@ -48,4 +48,3 @@ about:
   license: BSD-3
   summary: 'A JupyterLab extension for displaying dashboards of GPU usage.'
   dev_url: https://github.com/rapidsai/jupyterlab-nvdashboard
-

--- a/conda/recipes/jupyterlab-nvdashboard/meta.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/meta.yaml
@@ -48,3 +48,4 @@ about:
   license: BSD-3
   summary: 'A JupyterLab extension for displaying dashboards of GPU usage.'
   dev_url: https://github.com/rapidsai/jupyterlab-nvdashboard
+


### PR DESCRIPTION
This PR adds a version specification to `nodejs` in the `conda` recipe. The latest `nodejs` package version (`16.10.0`) seems to cause build errors for `jupyterlab-nvdashboard`.