### PR TITLE
Fix openssl build issue

### DIFF
--- a/conda/recipes/jupyterlab-nvdashboard/meta.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/meta.yaml
@@ -18,6 +18,7 @@ build:
     - CC
     - CXX
     - CUDAHOSTCXX
+    - NODE_OPTIONS=--openssl-legacy-provider
 
 requirements:
   host:


### PR DESCRIPTION
Due to an `openssl` upgrade in the latest `NodeJs` version, we need to enable the legacy `openssl` provider to fix the build until `jupyterlab` publish a new version with a fix for this