### PR TITLE
Make nvdashboard usable even when "NVML Shared Library Not Found"

### DIFF
--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -14,9 +14,15 @@ from jupyterlab_nvdashboard.utils import format_bytes
 KB = 1e3
 MB = KB * KB
 GB = MB * KB
-pynvml.nvmlInit()
-ngpus = pynvml.nvmlDeviceGetCount()
-gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(ngpus)]
+
+try:
+    pynvml.nvmlInit()
+except pynvml.nvml.NVMLError_LibraryNotFound as error:
+    ngpus = 0
+    gpu_handles = []
+else:
+    ngpus = pynvml.nvmlDeviceGetCount()
+    gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(ngpus)]
 
 
 def gpu(doc):

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -27,6 +27,10 @@ else:
         nvlink_ver = pynvml.nvmlDeviceGetNvLinkVersion(gpu_handles[0], 0)
     except (IndexError, pynvml.nvml.NVMLError_NotSupported):
         nvlink_ver = None
+    try:
+        pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
+    except (IndexError, pynvml.nvml.NVMLError_NotSupported):
+        pci_gen = None
 
 def gpu(doc):
     fig = figure(title="GPU Utilization", sizing_mode="stretch_both", x_range=[0, 100])
@@ -106,7 +110,6 @@ def gpu_mem(doc):
 def pci(doc):
 
     # Use device-0 to get "upper bound"
-    pci_gen = pynvml.nvmlDeviceGetMaxPcieLinkGeneration(gpu_handles[0])
     pci_width = pynvml.nvmlDeviceGetMaxPcieLinkWidth(gpu_handles[0])
     pci_bw = {
         # Keys = PCIe-Generation, Values = Max PCIe Lane BW (per direction)

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -23,7 +23,10 @@ except pynvml.nvml.NVMLError_LibraryNotFound as error:
 else:
     ngpus = pynvml.nvmlDeviceGetCount()
     gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(ngpus)]
-
+    try:
+        nvlink_ver = pynvml.nvmlDeviceGetNvLinkVersion(gpu_handles[0], 0)
+    except (IndexError, pynvml.nvml.NVMLError_NotSupported):
+        nvlink_ver = None
 
 def gpu(doc):
     fig = figure(title="GPU Utilization", sizing_mode="stretch_both", x_range=[0, 100])
@@ -202,7 +205,6 @@ def nvlink(doc):
     # Use device-0/link-0 to get "upper bound"
     counter = 1
     nlinks = pynvml.NVML_NVLINK_MAX_LINKS
-    nvlink_ver = pynvml.nvmlDeviceGetNvLinkVersion(gpu_handles[0], 0)
     nvlink_link_bw = {
         # Keys = NVLink Version, Values = Max Link BW (per direction)
         # [Note: Using specs at https://en.wikichip.org/wiki/nvidia/nvlink]

--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -19,7 +19,8 @@ if apps.gpu.ngpus > 0:
     routes["/GPU-Utilization"] = apps.gpu.gpu
     routes["/GPU-Memory"] = apps.gpu.gpu_mem
     routes["/GPU-Resources"] = apps.gpu.gpu_resource_timeline
-    routes["/PCIe-Throughput"] = apps.gpu.pci
+    if apps.gpu.pci_gen is not None:
+        routes["/PCIe-Throughput"] = apps.gpu.pci
     if apps.gpu.nvlink_ver is not None:
         routes["/NVLink-Throughput"] = apps.gpu.nvlink
         routes["/NVLink-Timeline"] = apps.gpu.nvlink_timeline

--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -11,16 +11,17 @@ DEFAULT_PORT = 8000
 
 
 routes = {
-    "/GPU-Utilization": apps.gpu.gpu,
-    "/GPU-Memory": apps.gpu.gpu_mem,
-    "/GPU-Resources": apps.gpu.gpu_resource_timeline,
-    "/PCIe-Throughput": apps.gpu.pci,
-    "/NVLink-Throughput": apps.gpu.nvlink,
-    "/NVLink-Timeline": apps.gpu.nvlink_timeline,
     # "/CPU-Utilization": apps.cpu.cpu,
     "/Machine-Resources": apps.cpu.resource_timeline,
 }
 
+if apps.gpu.ngpus > 0:
+    routes["/GPU-Utilization"] = apps.gpu.gpu
+    routes["/GPU-Memory"] = apps.gpu.gpu_mem
+    routes["/GPU-Resources"] = apps.gpu.gpu_resource_timeline
+    routes["/PCIe-Throughput"] = apps.gpu.pci
+    routes["/NVLink-Throughput"] = apps.gpu.nvlink
+    routes["/NVLink-Timeline"] = apps.gpu.nvlink_timeline
 
 class RouteIndex(web.RequestHandler):
     """ A JSON index of all routes present on the Bokeh Server """

--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -20,8 +20,9 @@ if apps.gpu.ngpus > 0:
     routes["/GPU-Memory"] = apps.gpu.gpu_mem
     routes["/GPU-Resources"] = apps.gpu.gpu_resource_timeline
     routes["/PCIe-Throughput"] = apps.gpu.pci
-    routes["/NVLink-Throughput"] = apps.gpu.nvlink
-    routes["/NVLink-Timeline"] = apps.gpu.nvlink_timeline
+    if apps.gpu.nvlink_ver is not None:
+        routes["/NVLink-Throughput"] = apps.gpu.nvlink
+        routes["/NVLink-Timeline"] = apps.gpu.nvlink_timeline
 
 class RouteIndex(web.RequestHandler):
     """ A JSON index of all routes present on the Bokeh Server """

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
     sidebar.id = 'nvdashboard-launcher';
     sidebar.title.iconClass = 'jp-GPU-icon jp-SideBar-tabIcon';
-    sidebar.title.caption = 'System Dashboards';
+    sidebar.title.caption = 'GPU Dashboards';
     labShell.add(sidebar, 'left');
 
     // An instance tracker which is used for state restoration.


### PR DESCRIPTION
We plan to deploy jupyterlab-nvdashboard on heterogenous HPC clusters with that nodes that do not all have GPUs, nor `libnvidia-ml.so.1` installed. This PR makes sure the dashboard that are not related to GPUs can be still be used when pynvml fails to initialize because CUDA drivers are not installed.

This is done by catching `pynvml.nvml.NVMLError_LibraryNotFound` in `gpu.py`. If the exception is raised, we consider that are no GPUs and set `ngpus = 0`. It would be valuable to log a warning here. I have not added any warning as nvdashboard currently never print nor log anything.

When comes the routes definition, if ngpus is greater than 0, we defines the routes related to GPU apps.