### PR TITLE
Remove compiler variables

### DIFF
--- a/conda/recipes/jupyterlab-nvdashboard/meta.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/meta.yaml
@@ -15,9 +15,6 @@ build:
   script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   noarch: python
   script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
     - NODE_OPTIONS=--openssl-legacy-provider
 
 requirements:


### PR DESCRIPTION
With the PR below merged, we no longer set the `CUDAHOSTCXX` variable in any of our CI images. This PR cleans up some references to `CUDAHOSTCXX`.


- https://github.com/rapidsai/gpuci-build-environment/pull/265

I don't think these variables were relevant to `jupyterlab-nvdashboard` anyway since it's just a JupyterLab extension.