### PR TITLE
Plot with legend_label option to remove BokehDeprecationWarnings

### DIFF
--- a/jupyterlab_nvdashboard/apps/cpu.py
+++ b/jupyterlab_nvdashboard/apps/cpu.py
@@ -84,8 +84,8 @@ def resource_timeline(doc):
         x_range=x_range,
         tools=tools,
     )
-    disk_fig.line(source=source, x="time", y="disk-read", color="blue", legend="Read")
-    disk_fig.line(source=source, x="time", y="disk-write", color="red", legend="Write")
+    disk_fig.line(source=source, x="time", y="disk-read", color="blue", legend_label="Read")
+    disk_fig.line(source=source, x="time", y="disk-write", color="red", legend_label="Write")
     disk_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
     disk_fig.legend.location = "top_left"
 
@@ -96,8 +96,8 @@ def resource_timeline(doc):
         x_range=x_range,
         tools=tools,
     )
-    net_fig.line(source=source, x="time", y="net-read", color="blue", legend="Recv")
-    net_fig.line(source=source, x="time", y="net-sent", color="red", legend="Send")
+    net_fig.line(source=source, x="time", y="net-read", color="blue", legend_label="Recv")
+    net_fig.line(source=source, x="time", y="net-sent", color="red", legend_label="Send")
     net_fig.yaxis.formatter = NumeralTickFormatter(format="0.0b")
     net_fig.legend.location = "top_left"
 

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -545,10 +545,10 @@ def gpu_resource_timeline(doc):
         tools=tools,
     )
     tot_fig.line(
-        source=source, x="time", y="gpu-total", color="blue", legend="Total-GPU"
+        source=source, x="time", y="gpu-total", color="blue", legend_label="Total-GPU"
     )
     tot_fig.line(
-        source=source, x="time", y="memory-total", color="red", legend="Total-Memory"
+        source=source, x="time", y="memory-total", color="red", legend_label="Total-Memory"
     )
     tot_fig.legend.location = "top_left"
 
@@ -561,8 +561,8 @@ def gpu_resource_timeline(doc):
             x_range=x_range,
             tools=tools,
         )
-        pci_fig.line(source=source, x="time", y="tx-total", color="blue", legend="TX")
-        pci_fig.line(source=source, x="time", y="rx-total", color="red", legend="RX")
+        pci_fig.line(source=source, x="time", y="tx-total", color="blue", legend_label="TX")
+        pci_fig.line(source=source, x="time", y="rx-total", color="red", legend_label="RX")
         pci_fig.yaxis.formatter = NumeralTickFormatter(format="0.0 b")
         pci_fig.legend.location = "top_left"
         figures.append(pci_fig)


### PR DESCRIPTION
FIx #131 

To remove BokehDeprecationWarnings, we changed the  `legend` option to `legend_label`.

To be sure, we also tried other options and found the following errors and display errors, so we do not think there is a problem with the modification.

- 'legend_field'.
```
ERROR:bokeh.core.validation.check:E-1001 (BAD_COLUMN_NAME): Glyph refers to nonexistent column name. This could either be due to a misspelling or typo, or due to an expected column being missing.
...
```

- 'legend_group'.
```
ERROR:tornado.application:Uncaught exception GET /Machine-Resources (127.0.0.1)
HTTPServerRequest(protocol='http', host='127.0.0.1:9090', method='GET', uri='/Machine-Resources', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
...
````