### PR TITLE
Update deprecated NVML API calls for NVLink query

### DIFF
--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -210,7 +210,7 @@ def _get_nvlink_throughput():
                 for scope_id in range(pynvml.NVML_NVLINK_MAX_LINKS)
             ] +
             [
-                (pynvml.NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX, scope_id)
+                (pynvml.NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX, scope_id)
                 for scope_id in range(pynvml.NVML_NVLINK_MAX_LINKS)
             ]
         )

--- a/jupyterlab_nvdashboard/apps/gpu.py
+++ b/jupyterlab_nvdashboard/apps/gpu.py
@@ -245,7 +245,11 @@ def _get_max_bandwidth():
         for handle in gpu_handles
     ]
 
-    return max(sum(i.value.ullVal for i in bw) * 1024**2 for bw in bandwidth)
+    # Maximum bandwidth is bidirectional, divide by two for separate RX and TX
+    return max(
+        sum(i.value.ullVal for i in bw) * 1024**2
+        for bw in bandwidth
+    ) / 2
 
 
 def nvlink(doc):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter-server-proxy
 bokeh>2.1
-pynvml
+pynvml>=11.0.0
 psutil
 jupyterlab>=3.0.0rc13,==3.*


### PR DESCRIPTION
Various of the NVML API calls to query for NVLink status have been deprecated since the CUDA 11.0 release. Resetting counters is also not allowed anymore.

New results:

![Screenshot 2022-06-20 at 20 07 53](https://user-images.githubusercontent.com/4398246/174658897-4d3e03e9-f1c2-4dc2-9dd9-62211dc5270d.png)

Fixes #28, #114