### PR TITLE
Patch bokeh version in requirements

### DIFF
--- a/conda/recipes/jupyterlab-nvdashboard/meta.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - python >=3.7
     - jupyterlab >=3.0.0,<4
     - jupyter-server-proxy >=1.3.2
-    - bokeh >2.1
+    - bokeh >2.1,<3
     - pynvml
     - psutil
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter-server-proxy
-bokeh>2.1
+bokeh>2.1,<3
 pynvml>=11.0.0
 psutil
 jupyterlab>=3.0.0rc13,==3.*


### PR DESCRIPTION
As noted in #141, the library is broken when using Bokeh 3. This PR does not fix that, it just ensures that the installed Bokeh version remains below 3.