### PR TITLE
fix docker container blank screen issue

### DIFF
--- a/jupyterlab_nvdashboard/server.py
+++ b/jupyterlab_nvdashboard/server.py
@@ -1,5 +1,5 @@
 import sys
-
+import os
 from bokeh.server.server import Server
 from tornado.ioloop import IOLoop
 from tornado import web
@@ -37,6 +37,8 @@ def go():
         port = int(sys.argv[1])
     else:
         port = DEFAULT_PORT
+
+    os.environ['BOKEH_RESOURCES'] = 'cdn'
     server = Server(routes, port=port, allow_websocket_origin=["*"])
     server.start()
 


### PR DESCRIPTION
This PR fixes an issue caused when running jupyterlab via docker containers (exposing only a few ports), leading to blank front-end screen, even when the bokeh server runs fine. 

The bokeh server is started in the background on some random port (default 8000), but is accessed in jupyterlab via jupyter-server-proxy, i.e., `localhost:8888/proxy/{port}/{resources}` . In a local env, we have access to {port} directly via localhost:{port}, that's why the extension works. In containers, that random port isn't exposed, so we have to make sure the resources are accessed (front-end bokeh resources) via the proxy urls, but they are being accessed directly, as seen in the screenshot below.
Hence the blank screen, due to no bokeh.js being available on the front-end.

Loading front-end resources via cdn would prevent access the resources via local addresses, and avoid the port mess altogether.