### PR TITLE
Remove usages of rapids-env-update

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,8 +4,11 @@
 # Exit script if any command fails
 set -euo pipefail
 
-# Source rapids-env-update to set environment variables
-source rapids-env-update
+rapids-configure-conda-channels
+
+source rapids-configure-sccache
+
+source rapids-date-string
 
 # Print the Rapids environment for debugging purposes
 rapids-print-env


### PR DESCRIPTION
Reference: https://github.com/rapidsai/ops/issues/2766

Replace rapids-env-update with rapids-configure-conda-channels, rapids-configure-sccache, and rapids-date-string.