### PR TITLE
add minimum size constraints to all widgets and remove vertical scroll

### DIFF
--- a/src/charts/GpuResourceChart.tsx
+++ b/src/charts/GpuResourceChart.tsx
@@ -67,7 +67,7 @@ const GpuResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={value => `${value}%`}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="gpu-resource-sync"
             >
               {gpuData[0] &&
@@ -92,7 +92,7 @@ const GpuResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={formatBytes}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="gpu-resource-sync"
             >
               {gpuData[0] &&
@@ -118,7 +118,7 @@ const GpuResourceChart = () => {
               yFormatter={value => `${value}%`}
               yDomain={[0, 100]}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="gpu-resource-sync"
             >
               <Line
@@ -148,7 +148,7 @@ const GpuResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={formatBytes}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="gpu-resource-sync"
             >
               <Line
@@ -216,6 +216,11 @@ const GpuResourceChart = () => {
 };
 
 export class GpuResourceChartWidget extends ReactWidget {
+  constructor() {
+    super();
+    /* Time series charts need to have a min height for seekbar to be visible without scrolling*/
+    this.addClass('size-constrained-widgets-lg');
+  }
   render() {
     return <GpuResourceChart />;
   }

--- a/src/charts/MachineResourceChart.tsx
+++ b/src/charts/MachineResourceChart.tsx
@@ -82,7 +82,7 @@ const MachineResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={value => `${value}%`}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="cpu-resource-sync"
             >
               <Line
@@ -99,7 +99,7 @@ const MachineResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={formatBytes}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="cpu-resource-sync"
             >
               <Line
@@ -116,7 +116,7 @@ const MachineResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={formatBytes}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="cpu-resource-sync"
             >
               <Line
@@ -140,7 +140,7 @@ const MachineResourceChart = () => {
               xFormatter={formatDate}
               yFormatter={formatBytes}
               width={width}
-              height={height / 5}
+              height={(height - 60) / 5}
               syncId="cpu-resource-sync"
             >
               <Line
@@ -201,6 +201,11 @@ const MachineResourceChart = () => {
 };
 
 export class MachineResourceChartWidget extends ReactWidget {
+  constructor() {
+    super();
+    /* Time series charts need to have a min height for seekbar to be visible without scrolling*/
+    this.addClass('size-constrained-widgets-lg');
+  }
   render() {
     return <MachineResourceChart />;
   }

--- a/src/launchWidget.tsx
+++ b/src/launchWidget.tsx
@@ -62,6 +62,7 @@ const Control: React.FC<IControlProps> = ({ app, labShell, tracker }) => {
       widgetInstance.title.label = title;
       widgetInstance.title.icon = gpuIcon;
       widgetInstance.id = id;
+      widgetInstance.addClass('size-constrained-widgets');
       app.shell.add(widgetInstance, 'main');
       tracker.add(widgetInstance);
       openWidgets.push({ id, title, instance: widgetInstance });

--- a/style/base.css
+++ b/style/base.css
@@ -31,13 +31,25 @@
     var(--jp-layout-color0),
     var(--jp-layout-color1)
   );
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: hidden;
   width: 100%;
   height: 100%;
   font-family: 'Courier New', Courier, monospace;
   word-spacing: 5px;
   font-variant: all-small-caps;
+}
+
+/* Time series charts need to have a min height for seekbar to be visible without scrolling*/
+.size-constrained-widgets-lg {
+  min-width: 25vw !important;
+  min-height: 45vh !important;
+}
+
+/* default min size constraints for all widgets */
+.size-constrained-widgets {
+  min-width: 25vw !important;
+  min-height: 25vh !important;
 }
 
 .gpu-dashboard-header {


### PR DESCRIPTION
This PR fixes #178 while also adding minimum size constraints(`[25vw, 25vw]`) to all plots, and a slightly larger minHeight(`45vh`) for timeseries plot to make sure the seekbar is always visible since we got rid of the vertical scroll.

cc @jacobtomlinson 

Preview: (No scrolls visible anymore)
![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/20476096/a2cdd579-e8b1-4bcf-a27a-77f7baf5ddf5)
