### PR TITLE
add dynamic updateFrequency via settingsRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "@jupyterlab/coreutils": "^6.0.0",
         "@jupyterlab/launcher": "^4.0.5",
         "@jupyterlab/services": "^7.0.0",
+        "@jupyterlab/settingregistry": "^4.1.0",
         "d3-format": "^3.1.0",
         "d3-scale": "^4.0.2",
         "react": "^18.2.0",

--- a/schema/config.json
+++ b/schema/config.json
@@ -7,7 +7,7 @@
       "type": "integer",
       "title": "Frequency of Updates",
       "description": "The frequency of updates for the GPU Dashboard widgets, in milliseconds.",
-      "default": 1000,
+      "default": 100,
       "minimum": 1
     }
   },

--- a/schema/config.json
+++ b/schema/config.json
@@ -1,0 +1,15 @@
+{
+  "title": "jupyterlab-nvdashboard",
+  "description": "Settings for the jupyterlab-nvdashboard extension.",
+  "type": "object",
+  "properties": {
+    "updateFrequency": {
+      "type": "integer",
+      "title": "Frequency of Updates",
+      "description": "The frequency of updates for the GPU Dashboard widgets, in milliseconds.",
+      "default": 1000,
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/assets/constants.ts
+++ b/src/assets/constants.ts
@@ -6,3 +6,4 @@ export const PLUGIN_ID_OPEN_SETTINGS = `${PLUGIN_ID}:open-settings`;
 export const WIDGET_TRACKER_NAME = 'gpu-dashboard-widgets';
 export const COMMAND_OPEN_SETTINGS = 'settingeditor:open';
 export const COMMAND_OPEN_WIDGET = 'gpu-dashboard-widget:open';
+export const DEFAULT_UPDATE_FREQUENCY = 100; // ms

--- a/src/assets/constants.ts
+++ b/src/assets/constants.ts
@@ -1,2 +1,8 @@
 export const BAR_COLOR_LINEAR_RANGE: string[] = ['#ff7900', '#b30000'];
 export const GPU_COLOR_CATEGORICAL_RANGE: string[] = ['#fecc5c', '#bd0026'];
+export const PLUGIN_ID = 'jupyterlab-nvdashboard';
+export const PLUGIN_ID_CONFIG = `${PLUGIN_ID}:config`;
+export const PLUGIN_ID_OPEN_SETTINGS = `${PLUGIN_ID}:open-settings`;
+export const WIDGET_TRACKER_NAME = 'gpu-dashboard-widgets';
+export const COMMAND_OPEN_SETTINGS = 'settingeditor:open';
+export const COMMAND_OPEN_WIDGET = 'gpu-dashboard-widget:open';

--- a/src/assets/hooks.ts
+++ b/src/assets/hooks.ts
@@ -1,0 +1,33 @@
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { SetStateAction, useEffect } from 'react';
+import { PLUGIN_ID_CONFIG } from './constants';
+
+function loadSettingRegistry(
+  settingRegistry: ISettingRegistry,
+  setUpdateFrequency: {
+    (value: SetStateAction<number>): void;
+    (arg0: number): void;
+  }
+) {
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const settings = await settingRegistry.load(PLUGIN_ID_CONFIG);
+        const loadedUpdateFrequency =
+          (settings.get('updateFrequency').composite as number) || 1000;
+        setUpdateFrequency(loadedUpdateFrequency);
+
+        settings.changed.connect(() => {
+          setUpdateFrequency(
+            (settings.get('updateFrequency').composite as number) || 1000
+          );
+        });
+      } catch (error) {
+        console.error(`An error occurred while loading settings: ${error}`);
+      }
+    };
+    loadSettings();
+  }, []);
+}
+
+export default loadSettingRegistry;

--- a/src/assets/hooks.ts
+++ b/src/assets/hooks.ts
@@ -1,6 +1,6 @@
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { SetStateAction, useEffect } from 'react';
-import { PLUGIN_ID_CONFIG } from './constants';
+import { DEFAULT_UPDATE_FREQUENCY, PLUGIN_ID_CONFIG } from './constants';
 
 function loadSettingRegistry(
   settingRegistry: ISettingRegistry,
@@ -14,12 +14,14 @@ function loadSettingRegistry(
       try {
         const settings = await settingRegistry.load(PLUGIN_ID_CONFIG);
         const loadedUpdateFrequency =
-          (settings.get('updateFrequency').composite as number) || 1000;
+          (settings.get('updateFrequency').composite as number) ||
+          DEFAULT_UPDATE_FREQUENCY;
         setUpdateFrequency(loadedUpdateFrequency);
 
         settings.changed.connect(() => {
           setUpdateFrequency(
-            (settings.get('updateFrequency').composite as number) || 1000
+            (settings.get('updateFrequency').composite as number) ||
+              DEFAULT_UPDATE_FREQUENCY
           );
         });
       } catch (error) {

--- a/src/assets/interfaces.ts
+++ b/src/assets/interfaces.ts
@@ -1,0 +1,20 @@
+import { ILabShell, JupyterFrontEnd } from '@jupyterlab/application';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
+
+export interface IChartProps {
+  settingRegistry: ISettingRegistry;
+}
+
+export interface IControlProps {
+  app: JupyterFrontEnd;
+  labShell: ILabShell;
+  tracker: WidgetTracker;
+  settingRegistry: ISettingRegistry;
+}
+
+export interface IWidgetInfo {
+  id: string;
+  title: string;
+  instance: MainAreaWidget;
+}

--- a/src/charts/GpuMemoryChart.tsx
+++ b/src/charts/GpuMemoryChart.tsx
@@ -12,7 +12,10 @@ import {
 } from 'recharts';
 import { scaleLinear } from 'd3-scale';
 import { renderCustomTooltip } from '../components/tooltipUtils';
-import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
+import {
+  BAR_COLOR_LINEAR_RANGE,
+  DEFAULT_UPDATE_FREQUENCY
+} from '../assets/constants';
 import { format } from 'd3-format';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -24,7 +27,9 @@ const GpuMemoryChart: React.FC<IChartProps> = ({
 }): JSX.Element => {
   const [gpuMemory, setGpuMemory] = useState([]);
   const [gpuTotalMemory, setGpuTotalMemory] = useState([]);
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/GpuMemoryChart.tsx
+++ b/src/charts/GpuMemoryChart.tsx
@@ -120,6 +120,7 @@ const GpuMemoryChart: React.FC<IChartProps> = ({
 export class GpuMemoryChartWidget extends ReactWidget {
   constructor(private settingRegistry: ISettingRegistry) {
     super();
+    this.addClass('size-constrained-widgets');
     this.settingRegistry = settingRegistry;
   }
   render(): JSX.Element {

--- a/src/charts/GpuMemoryChart.tsx
+++ b/src/charts/GpuMemoryChart.tsx
@@ -15,10 +15,18 @@ import { renderCustomTooltip } from '../components/tooltipUtils';
 import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
 import { format } from 'd3-format';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import loadSettingRegistry from '../assets/hooks';
+import { IChartProps } from '../assets/interfaces';
 
-const GpuMemoryChart = (): JSX.Element => {
+const GpuMemoryChart: React.FC<IChartProps> = ({
+  settingRegistry
+}): JSX.Element => {
   const [gpuMemory, setGpuMemory] = useState([]);
   const [gpuTotalMemory, setGpuTotalMemory] = useState([]);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+
+  loadSettingRegistry(settingRegistry, setUpdateFrequency);
 
   useEffect(() => {
     async function fetchGPUMemory() {
@@ -39,7 +47,7 @@ const GpuMemoryChart = (): JSX.Element => {
     }
     const intervalId = setInterval(() => {
       fetchGPUMemory();
-    }, 1000);
+    }, updateFrequency);
 
     return () => clearInterval(intervalId);
   }, []);
@@ -105,7 +113,11 @@ const GpuMemoryChart = (): JSX.Element => {
 };
 
 export class GpuMemoryChartWidget extends ReactWidget {
+  constructor(private settingRegistry: ISettingRegistry) {
+    super();
+    this.settingRegistry = settingRegistry;
+  }
   render(): JSX.Element {
-    return <GpuMemoryChart />;
+    return <GpuMemoryChart settingRegistry={this.settingRegistry} />;
   }
 }

--- a/src/charts/GpuResourceChart.tsx
+++ b/src/charts/GpuResourceChart.tsx
@@ -6,7 +6,10 @@ import { requestAPI } from '../handler';
 import { CustomLineChart } from '../components/customLineChart';
 import { formatDate, formatBytes } from '../components/formatUtils';
 import { scaleLinear } from 'd3-scale';
-import { GPU_COLOR_CATEGORICAL_RANGE } from '../assets/constants';
+import {
+  DEFAULT_UPDATE_FREQUENCY,
+  GPU_COLOR_CATEGORICAL_RANGE
+} from '../assets/constants';
 import { pauseIcon, playIcon } from '../assets/icons';
 import loadSettingRegistry from '../assets/hooks';
 import { IChartProps } from '../assets/interfaces';
@@ -27,7 +30,9 @@ const GpuResourceChart: React.FC<IChartProps> = ({ settingRegistry }) => {
   const [tempData, setTempData] = useState<IDataProps[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const ngpus = gpuData[0]?.gpu_utilization_individual.length || 0;
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/GpuUtilizationChart.tsx
+++ b/src/charts/GpuUtilizationChart.tsx
@@ -14,9 +14,17 @@ import { scaleLinear } from 'd3-scale';
 import { renderCustomTooltip } from '../components/tooltipUtils';
 import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { IChartProps } from '../assets/interfaces';
+import loadSettingRegistry from '../assets/hooks';
 
-const GpuUtilizationChart = (): JSX.Element => {
+const GpuUtilizationChart: React.FC<IChartProps> = ({
+  settingRegistry
+}): JSX.Element => {
   const [gpuUtilization, setGpuUtilization] = useState([]);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+
+  loadSettingRegistry(settingRegistry, setUpdateFrequency);
 
   useEffect(() => {
     async function fetchGPUUtilization() {
@@ -34,7 +42,7 @@ const GpuUtilizationChart = (): JSX.Element => {
     }
     const intervalId = setInterval(() => {
       fetchGPUUtilization();
-    }, 1000);
+    }, updateFrequency);
 
     return () => clearInterval(intervalId);
   }, []);
@@ -99,7 +107,12 @@ const GpuUtilizationChart = (): JSX.Element => {
 };
 
 export class GpuUtilizationChartWidget extends ReactWidget {
+  constructor(private settingRegistry: ISettingRegistry) {
+    super();
+    this.settingRegistry = settingRegistry;
+  }
+
   render(): JSX.Element {
-    return <GpuUtilizationChart />;
+    return <GpuUtilizationChart settingRegistry={this.settingRegistry} />;
   }
 }

--- a/src/charts/GpuUtilizationChart.tsx
+++ b/src/charts/GpuUtilizationChart.tsx
@@ -114,6 +114,7 @@ const GpuUtilizationChart: React.FC<IChartProps> = ({
 export class GpuUtilizationChartWidget extends ReactWidget {
   constructor(private settingRegistry: ISettingRegistry) {
     super();
+    this.addClass('size-constrained-widgets');
     this.settingRegistry = settingRegistry;
   }
 

--- a/src/charts/GpuUtilizationChart.tsx
+++ b/src/charts/GpuUtilizationChart.tsx
@@ -12,7 +12,10 @@ import {
 } from 'recharts';
 import { scaleLinear } from 'd3-scale';
 import { renderCustomTooltip } from '../components/tooltipUtils';
-import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
+import {
+  BAR_COLOR_LINEAR_RANGE,
+  DEFAULT_UPDATE_FREQUENCY
+} from '../assets/constants';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IChartProps } from '../assets/interfaces';
@@ -22,7 +25,9 @@ const GpuUtilizationChart: React.FC<IChartProps> = ({
   settingRegistry
 }): JSX.Element => {
   const [gpuUtilization, setGpuUtilization] = useState([]);
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/MachineResourceChart.tsx
+++ b/src/charts/MachineResourceChart.tsx
@@ -6,7 +6,10 @@ import { requestAPI } from '../handler';
 import { CustomLineChart } from '../components/customLineChart';
 import { formatDate, formatBytes } from '../components/formatUtils';
 import { scaleLinear } from 'd3-scale';
-import { GPU_COLOR_CATEGORICAL_RANGE } from '../assets/constants';
+import {
+  DEFAULT_UPDATE_FREQUENCY,
+  GPU_COLOR_CATEGORICAL_RANGE
+} from '../assets/constants';
 import { pauseIcon, playIcon } from '../assets/icons';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IChartProps } from '../assets/interfaces';
@@ -30,7 +33,9 @@ const MachineResourceChart: React.FC<IChartProps> = ({ settingRegistry }) => {
   const [cpuData, setCpuData] = useState<IDataProps[]>([]);
   const [tempData, setTempData] = useState<IDataProps[]>([]);
   const [isPaused, setIsPaused] = useState(false);
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/NvLinkThroughputChart.tsx
+++ b/src/charts/NvLinkThroughputChart.tsx
@@ -7,19 +7,25 @@ import { renderCustomTooltip } from '../components/tooltipUtils';
 import { format } from 'd3-format';
 import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import { IChartProps } from '../assets/interfaces';
+import loadSettingRegistry from '../assets/hooks';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-interface INvLinkChartProps {
+interface IDataProps {
   nvlink_tx: number[];
   nvlink_rx: number[];
   max_rxtx_bw: number;
 }
 
-const NvLinkThroughputChart = (): JSX.Element => {
-  const [nvlinkStats, setNvLinkStats] = useState<INvLinkChartProps>();
+const NvLinkThroughputChart: React.FC<IChartProps> = ({ settingRegistry }) => {
+  const [nvlinkStats, setNvLinkStats] = useState<IDataProps>();
+  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+
+  loadSettingRegistry(settingRegistry, setUpdateFrequency);
 
   useEffect(() => {
     async function fetchGPUMemory() {
-      const response = await requestAPI<INvLinkChartProps>('nvlink_throughput');
+      const response = await requestAPI<IDataProps>('nvlink_throughput');
       console.log(response);
       setNvLinkStats(response);
     }
@@ -29,12 +35,12 @@ const NvLinkThroughputChart = (): JSX.Element => {
 
   useEffect(() => {
     async function fetchGPUMemory() {
-      const response = await requestAPI<INvLinkChartProps>('nvlink_throughput');
+      const response = await requestAPI<IDataProps>('nvlink_throughput');
       setNvLinkStats(response);
     }
     const intervalId = setInterval(() => {
       fetchGPUMemory();
-    }, 1000);
+    }, updateFrequency);
 
     return () => clearInterval(intervalId);
   }, []);
@@ -138,7 +144,11 @@ const NvLinkThroughputChart = (): JSX.Element => {
 };
 
 export class NvLinkThroughputChartWidget extends ReactWidget {
+  constructor(private settingRegistry: ISettingRegistry) {
+    super();
+    this.settingRegistry = settingRegistry;
+  }
   render(): JSX.Element {
-    return <NvLinkThroughputChart />;
+    return <NvLinkThroughputChart settingRegistry={this.settingRegistry} />;
   }
 }

--- a/src/charts/NvLinkThroughputChart.tsx
+++ b/src/charts/NvLinkThroughputChart.tsx
@@ -151,6 +151,7 @@ const NvLinkThroughputChart: React.FC<IChartProps> = ({ settingRegistry }) => {
 export class NvLinkThroughputChartWidget extends ReactWidget {
   constructor(private settingRegistry: ISettingRegistry) {
     super();
+    this.addClass('size-constrained-widgets');
     this.settingRegistry = settingRegistry;
   }
   render(): JSX.Element {

--- a/src/charts/NvLinkThroughputChart.tsx
+++ b/src/charts/NvLinkThroughputChart.tsx
@@ -5,7 +5,10 @@ import { BarChart, Bar, Cell, YAxis, XAxis, Tooltip } from 'recharts';
 import { scaleLinear } from 'd3-scale';
 import { renderCustomTooltip } from '../components/tooltipUtils';
 import { format } from 'd3-format';
-import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
+import {
+  BAR_COLOR_LINEAR_RANGE,
+  DEFAULT_UPDATE_FREQUENCY
+} from '../assets/constants';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { IChartProps } from '../assets/interfaces';
 import loadSettingRegistry from '../assets/hooks';
@@ -19,7 +22,9 @@ interface IDataProps {
 
 const NvLinkThroughputChart: React.FC<IChartProps> = ({ settingRegistry }) => {
   const [nvlinkStats, setNvLinkStats] = useState<IDataProps>();
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/NvLinkTimelineChart.tsx
+++ b/src/charts/NvLinkTimelineChart.tsx
@@ -7,7 +7,10 @@ import { Line, XAxis, YAxis, Brush, LineChart } from 'recharts';
 import { formatDate, formatBytes } from '../components/formatUtils';
 import { pauseIcon, playIcon } from '../assets/icons';
 import { scaleLinear } from 'd3-scale';
-import { GPU_COLOR_CATEGORICAL_RANGE } from '../assets/constants';
+import {
+  DEFAULT_UPDATE_FREQUENCY,
+  GPU_COLOR_CATEGORICAL_RANGE
+} from '../assets/constants';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IChartProps } from '../assets/interfaces';
 import loadSettingRegistry from '../assets/hooks';
@@ -24,7 +27,9 @@ const NvLinkTimelineChart: React.FC<IChartProps> = ({ settingRegistry }) => {
   const [tempData, setTempData] = useState<IDataProps[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const ngpus = nvlinkStats[0]?.nvlink_tx.length || 0;
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/charts/NvLinkTimelineChart.tsx
+++ b/src/charts/NvLinkTimelineChart.tsx
@@ -8,23 +8,29 @@ import { formatDate, formatBytes } from '../components/formatUtils';
 import { pauseIcon, playIcon } from '../assets/icons';
 import { scaleLinear } from 'd3-scale';
 import { GPU_COLOR_CATEGORICAL_RANGE } from '../assets/constants';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { IChartProps } from '../assets/interfaces';
+import loadSettingRegistry from '../assets/hooks';
 
-interface INvLinkChartProps {
+interface IDataProps {
   time: number;
   nvlink_tx: number[];
   nvlink_rx: number[];
   max_rxtx_bw: number;
 }
 
-const NvLinkTimelineChart = (): JSX.Element => {
-  const [nvlinkStats, setNvLinkStats] = useState<INvLinkChartProps[]>([]);
-  const [tempData, setTempData] = useState<INvLinkChartProps[]>([]);
+const NvLinkTimelineChart: React.FC<IChartProps> = ({ settingRegistry }) => {
+  const [nvlinkStats, setNvLinkStats] = useState<IDataProps[]>([]);
+  const [tempData, setTempData] = useState<IDataProps[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const ngpus = nvlinkStats[0]?.nvlink_tx.length || 0;
+  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+
+  loadSettingRegistry(settingRegistry, setUpdateFrequency);
 
   useEffect(() => {
     async function fetchNvLinkStats() {
-      const response = await requestAPI<INvLinkChartProps>('nvlink_throughput');
+      const response = await requestAPI<IDataProps>('nvlink_throughput');
       response.time = Date.now();
       if (!isPaused) {
         setNvLinkStats(prevData => {
@@ -40,7 +46,7 @@ const NvLinkTimelineChart = (): JSX.Element => {
       }
     }
 
-    const interval = setInterval(fetchNvLinkStats, 1000);
+    const interval = setInterval(fetchNvLinkStats, updateFrequency);
 
     return () => clearInterval(interval);
   }, [isPaused, tempData]);
@@ -151,7 +157,11 @@ const NvLinkTimelineChart = (): JSX.Element => {
 };
 
 export class NvLinkTimelineChartWidget extends ReactWidget {
+  constructor(private settingRegistry: ISettingRegistry) {
+    super();
+    this.settingRegistry = settingRegistry;
+  }
   render(): JSX.Element {
-    return <NvLinkTimelineChart />;
+    return <NvLinkTimelineChart settingRegistry={this.settingRegistry} />;
   }
 }

--- a/src/charts/NvLinkTimelineChart.tsx
+++ b/src/charts/NvLinkTimelineChart.tsx
@@ -164,6 +164,7 @@ const NvLinkTimelineChart: React.FC<IChartProps> = ({ settingRegistry }) => {
 export class NvLinkTimelineChartWidget extends ReactWidget {
   constructor(private settingRegistry: ISettingRegistry) {
     super();
+    this.addClass('size-constrained-widgets');
     this.settingRegistry = settingRegistry;
   }
   render(): JSX.Element {

--- a/src/charts/PciThroughputChart.tsx
+++ b/src/charts/PciThroughputChart.tsx
@@ -146,6 +146,7 @@ const PciThroughputChart: React.FC<IChartProps> = ({ settingRegistry }) => {
 export class PciThroughputChartWidget extends ReactWidget {
   constructor(private settingRegistry: ISettingRegistry) {
     super();
+    this.addClass('size-constrained-widgets');
     this.settingRegistry = settingRegistry;
   }
   render(): JSX.Element {

--- a/src/charts/PciThroughputChart.tsx
+++ b/src/charts/PciThroughputChart.tsx
@@ -6,7 +6,10 @@ import { scaleLinear } from 'd3-scale';
 import { renderCustomTooltip } from '../components/tooltipUtils';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { formatBytes } from '../components/formatUtils';
-import { BAR_COLOR_LINEAR_RANGE } from '../assets/constants';
+import {
+  BAR_COLOR_LINEAR_RANGE,
+  DEFAULT_UPDATE_FREQUENCY
+} from '../assets/constants';
 import { IChartProps } from '../assets/interfaces';
 import loadSettingRegistry from '../assets/hooks';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -18,7 +21,9 @@ interface IDataProps {
 
 const PciThroughputChart: React.FC<IChartProps> = ({ settingRegistry }) => {
   const [pciStats, setPciStats] = useState<IDataProps>();
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,44 +4,77 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ControlWidget } from './launchWidget';
 import { MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 import { gpuIcon } from './assets/icons';
+import {
+  COMMAND_OPEN_SETTINGS,
+  COMMAND_OPEN_WIDGET,
+  PLUGIN_ID,
+  PLUGIN_ID_CONFIG,
+  PLUGIN_ID_OPEN_SETTINGS,
+  WIDGET_TRACKER_NAME
+} from './assets/constants';
 
 /**
  * Initialization data for the react-widget extension.
  */
 const extension: JupyterFrontEndPlugin<void> = {
-  id: 'react-widget',
+  id: PLUGIN_ID,
   description: 'A minimal JupyterLab extension using a React Widget.',
   autoStart: true,
-  requires: [ILabShell],
+  requires: [ILabShell, ISettingRegistry],
   optional: [ILayoutRestorer],
   activate: (
     app: JupyterFrontEnd,
     labShell: ILabShell,
+    settingRegistry: ISettingRegistry,
     restorer: ILayoutRestorer | null
   ) => {
     const tracker = new WidgetTracker<MainAreaWidget>({
-      namespace: 'gpu-dashboard-widgets'
+      namespace: WIDGET_TRACKER_NAME
     });
-    const controlWidget = new ControlWidget(app, labShell, tracker);
+
+    app.commands.addCommand(PLUGIN_ID_OPEN_SETTINGS, {
+      label: 'Open Settings',
+      execute: () => {
+        app.commands.execute(COMMAND_OPEN_SETTINGS, {
+          query: PLUGIN_ID
+        });
+      }
+    });
+
+    settingRegistry
+      .load(PLUGIN_ID_CONFIG)
+      .then(settings => {
+        console.log(`${PLUGIN_ID} settings loaded`);
+      })
+      .catch(reason => {
+        console.error(`Failed to load settings for ${PLUGIN_ID}.`, reason);
+      });
+
+    const controlWidget = new ControlWidget(
+      app,
+      labShell,
+      tracker,
+      settingRegistry
+    );
     controlWidget.id = 'gpu-dashboard';
     controlWidget.title.icon = gpuIcon;
     controlWidget.title.caption = 'GPU Dashboards';
 
-    // If there is a restorer, restore the widget
     if (restorer) {
       // Add state restoration for the widget so they can be restored on reload
       restorer.add(controlWidget, 'gpu-dashboard');
       // Track and restore the chart widgets states so they can be restored on reload
       restorer.restore(tracker, {
-        command: 'gpu-dashboard-widget:open',
+        command: COMMAND_OPEN_WIDGET,
         args: widget => ({ id: widget.id, title: widget.title.label }),
         name: widget => widget.title.label
       });
     }
-
+    // If there is a restorer, restore the widget
     // Add control widget to the left area
     labShell.add(controlWidget, 'left', { rank: 200 });
   }

--- a/src/launchWidget.tsx
+++ b/src/launchWidget.tsx
@@ -75,7 +75,6 @@ const Control: React.FC<IControlProps> = ({
       widgetInstance.title.caption = title;
       widgetInstance.title.icon = gpuIcon;
       widgetInstance.id = id;
-      widgetInstance.addClass('size-constrained-widgets');
       app.shell.add(widgetInstance, 'main');
       tracker.add(widgetInstance);
       openWidgets.push({ id, title, instance: widgetInstance });

--- a/src/launchWidget.tsx
+++ b/src/launchWidget.tsx
@@ -21,6 +21,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IControlProps, IWidgetInfo } from './assets/interfaces';
 import {
   COMMAND_OPEN_WIDGET,
+  DEFAULT_UPDATE_FREQUENCY,
   PLUGIN_ID_OPEN_SETTINGS
 } from './assets/constants';
 import loadSettingRegistry from './assets/hooks';
@@ -34,7 +35,9 @@ const Control: React.FC<IControlProps> = ({
 }) => {
   // Keep track of open widgets
   const openWidgets: IWidgetInfo[] = [];
-  const [updateFrequency, setUpdateFrequency] = useState<number>(1000);
+  const [updateFrequency, setUpdateFrequency] = useState<number>(
+    DEFAULT_UPDATE_FREQUENCY
+  );
 
   loadSettingRegistry(settingRegistry, setUpdateFrequency);
 

--- a/style/base.css
+++ b/style/base.css
@@ -41,11 +41,23 @@
 }
 
 .gpu-dashboard-header {
+  display: flex; /* Use flexbox layout */
+  align-items: center; /* Align items vertically */
+  justify-content: space-between; /* Space evenly between items */
   font-size: 25px; /* Adjust font size */
   font-weight: bold;
   margin-bottom: 10px;
-  align-self: flex-start; /* Left align the header */
   color: #ff7900;
+}
+
+.gpu-dashboard-footer {
+  font-size: 18px;
+  color: #ff7900;
+  margin-top: 30px;
+}
+
+.gpu-dashboard-footer-body {
+  font-variant: petite-caps;
 }
 
 .gpu-dashboard-divider {
@@ -53,6 +65,13 @@
   border: none;
   border-top: 1px solid #ff7900;
   margin: -8px -5px 10px 0;
+}
+
+.header-text {
+  align-self: flex-start; /* Align text to the left */
+}
+.header-button {
+  background: transparent;
 }
 
 .gpu-dashboard-button {
@@ -114,6 +133,14 @@
 
 .gpu-dashboard-toolbar-button {
   height: 40px;
+}
+
+.nv-header-icon:hover {
+  stroke: #ff7900;
+}
+
+.nv-header-icon svg path {
+  fill: #ff7900 !important;
 }
 
 .nv-icon-custom {

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,6 +439,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@jupyterlab/nbformat@npm:4.1.0"
+  dependencies:
+    "@lumino/coreutils": ^2.1.2
+  checksum: 0f10f53d312e1ad386be0cd1db3ea8d76ac5e169a1c470465179b35c7d7bd0e55b9d450b64abe38f447dcbec71224bfe8d4115a1cdb433f986d3a91234ffd391
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/observables@npm:^5.0.6":
   version: 5.0.6
   resolution: "@jupyterlab/observables@npm:5.0.6"
@@ -520,6 +529,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@jupyterlab/settingregistry@npm:4.1.0"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.1.0
+    "@jupyterlab/statedb": ^4.1.0
+    "@lumino/commands": ^2.2.0
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/signaling": ^2.1.2
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: 1a0c52016806ceda150168cdeae966b15afce454fe24acfd68939f3f380eaf2d4390c40e27c1475877c8e8da6b3f15a952999ebcc9d3838d5306bd24ad5b4b51
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/statedb@npm:4.0.6"
@@ -530,6 +558,19 @@ __metadata:
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
   checksum: de507d094afcce7f7d12f9dc846788765616140b2f75ea22997f780056baaaadae0cf9683471a1d96c61d448b38860640c823302aeef0d5e5d7c9cf598074328
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@jupyterlab/statedb@npm:4.1.0"
+  dependencies:
+    "@lumino/commands": ^2.2.0
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/properties": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+  checksum: 693d40ba6ce67b41aae2acbae027a5c637c2bfa51d7085b6faecdb1877a5e3bd43ca70f3670f88f038c49bef80e0e09899b05d330dd9010b1d578ca73b13ea17
   languageName: node
   linkType: hard
 
@@ -630,6 +671,21 @@ __metadata:
     "@lumino/signaling": ^2.1.2
     "@lumino/virtualdom": ^2.0.1
   checksum: e4e3ee279f2a5e8d68e4ce142c880333f5542f90c684972402356936ecb5cf5e07163800b59e7cb8c911cbdb4e5089edcc5dd2990bc8db10c87517268de1fc5d
+  languageName: node
+  linkType: hard
+
+"@lumino/commands@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@lumino/commands@npm:2.2.0"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/domutils": ^2.0.1
+    "@lumino/keyboard": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+    "@lumino/virtualdom": ^2.0.1
+  checksum: 093e9715491e5cef24bc80665d64841417b400f2fa595f9b60832a3b6340c405c94a6aa276911944a2c46d79a6229f3cc087b73f50852bba25ece805abd0fae9
   languageName: node
   linkType: hard
 
@@ -815,6 +871,21 @@ __metadata:
   peerDependencies:
     react: ^16.14.0 || >=17
   checksum: 283e2b405eac2f4fdd243b2e35ade7e83a4bf7551eb5e075499e8eb5d3a3ae161e9c047bcf63d2e6fef7c6b2e7438f1a150f353b909df992e85194940c311f9b
+  languageName: node
+  linkType: hard
+
+"@rjsf/utils@npm:^5.13.4":
+  version: 5.17.0
+  resolution: "@rjsf/utils@npm:5.17.0"
+  dependencies:
+    json-schema-merge-allof: ^0.8.1
+    jsonpointer: ^5.0.1
+    lodash: ^4.17.21
+    lodash-es: ^4.17.21
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^16.14.0 || >=17
+  checksum: 01d0001f83083764a8552e009aa7df084621df9d1fc6ccdfad9d534513084421b1ad7494cab77b9b8205d680fd915f612d87800e20ab242e7066f33184c73d4f
   languageName: node
   linkType: hard
 
@@ -3590,6 +3661,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/launcher": ^4.0.5
     "@jupyterlab/services": ^7.0.0
+    "@jupyterlab/settingregistry": ^4.1.0
     "@types/d3-format": ^3.0.1
     "@types/d3-scale": ^4.0.4
     "@types/json-schema": ^7.0.11


### PR DESCRIPTION
Implements #179. Also added the ability to set a custom refresh speed via jupyterlab settings. The settings once set will be global across the jupyterlab session, even when you restart the jupyterlab server. The setting also has type checking along with a minimum value of 1ms.

cc @jacobtomlinson 

![Recording 2024-02-07 at 14 36 28](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/20476096/d8b46485-b816-4def-917a-d4e513ce9d21)
