### PR TITLE
enable forward merger plugin

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,4 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+forward_merger: true


### PR DESCRIPTION
This PR enables the ForwardMerger [ops-bot](https://github.com/rapidsai/ops-bot) plugin.