### PR TITLE
Add authentication to ws requests

### DIFF
--- a/jupyterlab_nvdashboard/apps/utils.py
+++ b/jupyterlab_nvdashboard/apps/utils.py
@@ -1,10 +1,15 @@
 from tornado.websocket import WebSocketHandler
+from jupyter_server.base.handlers import JupyterHandler
 import tornado
 import json
 
 
-class CustomWebSocketHandler(WebSocketHandler):
+class CustomWebSocketHandler(JupyterHandler, WebSocketHandler):
     def open(self):
+        if not self.current_user:
+            self.write_message(json.dumps({"error": "Unauthorized access"}))
+            self.close()
+            return
         self.write_message(json.dumps({"status": "connected"}))
         self.set_nodelay(True)
         # Start a periodic callback to send data every 50ms

--- a/jupyterlab_nvdashboard/tests/test_cpu_handlers.py
+++ b/jupyterlab_nvdashboard/tests/test_cpu_handlers.py
@@ -20,8 +20,12 @@ def handler_args():
     with patch("tornado.web.Application") as mock_application, patch(
         "tornado.httputil.HTTPServerRequest"
     ) as mock_request:
+        # Mock the settings to return appropriate values
+        mock_settings = {
+            "base_url": "/",
+        }
+        mock_application.settings = mock_settings
         yield mock_application, mock_request
-
 
 def test_cpu_resource_handler(mock_handler, handler_args):
     handler = CPUResourceWebSocketHandler(*handler_args)

--- a/jupyterlab_nvdashboard/tests/test_cpu_handlers.py
+++ b/jupyterlab_nvdashboard/tests/test_cpu_handlers.py
@@ -27,6 +27,7 @@ def handler_args():
         mock_application.settings = mock_settings
         yield mock_application, mock_request
 
+
 def test_cpu_resource_handler(mock_handler, handler_args):
     handler = CPUResourceWebSocketHandler(*handler_args)
     handler.send_data()

--- a/jupyterlab_nvdashboard/tests/test_gpu_handlers.py
+++ b/jupyterlab_nvdashboard/tests/test_gpu_handlers.py
@@ -26,6 +26,11 @@ def handler_args():
     with patch("tornado.web.Application") as mock_application, patch(
         "tornado.httputil.HTTPServerRequest"
     ) as mock_request:
+        # Mock the settings to return appropriate values
+        mock_settings = {
+            "base_url": "/",
+        }
+        mock_application.settings = mock_settings
         yield mock_application, mock_request
 
 


### PR DESCRIPTION
This PR adds authentication to WS requests, using the inbuilt `self.current_user` method in jupyter_handler, without which the ws requests will not be served.

<img width="509" alt="image" src="https://github.com/rapidsai/jupyterlab-nvdashboard/assets/20476096/84bd0a07-4c23-4d55-b76a-d7e23a6821d7">
