### PR TITLE
Harmonize the icon color with the standard color

### DIFF
--- a/style/icons/expansion-card.svg
+++ b/style/icons/expansion-card.svg
@@ -1,4 +1,4 @@
 <svg width="26" height="11" viewBox="0 0 26 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" class="jp-icon0" clip-rule="evenodd" d="M26 0H4V9H6V11H15V9H26V0ZM21.5 7C22.8807 7 24 5.88071 24 4.5C24 3.11929 22.8807 2 21.5 2C20.1193 2 19 3.11929 19 4.5C19 5.88071 20.1193 7 21.5 7Z" fill="#E0E0E0"/>
-<path d="M0 0H3V11H1V2H0V0Z" class="jp-icon0" fill="#E0E0E0"/>
+<path fill-rule="evenodd" class="jp-icon3" clip-rule="evenodd" d="M26 0H4V9H6V11H15V9H26V0ZM21.5 7C22.8807 7 24 5.88071 24 4.5C24 3.11929 22.8807 2 21.5 2C20.1193 2 19 3.11929 19 4.5C19 5.88071 20.1193 7 21.5 7Z" fill="#E0E0E0"/>
+<path d="M0 0H3V11H1V2H0V0Z" class="jp-icon3" fill="#E0E0E0"/>
 </svg>


### PR DESCRIPTION
Changes the `expansion-card.svg` code from `jp-icon0` class to `jp-icon3` which is more appropriate for sidebar/window icons in JupyterLab design style.

Fixes https://github.com/rapidsai/jupyterlab-nvdashboard/issues/199

#### Light theme

| Before | After |
| -- | -- |
| ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/0d660026-05ff-46d2-b3f2-82018a59c596) |  ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/86817c02-751d-45c5-aeed-032a4700a31e) |

#### Dark theme

| Before | After |
| -- | -- |
| ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/8ace1694-a9d8-4053-8047-233f26e9362c) | ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/bccf43fa-5f51-4dcd-8713-1299864ccd11) |

#### High contrast dark theme

| Before | After |
| -- | -- |
| ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/db8e4eea-f767-4e64-8672-8a799e8baf0d) | ![image](https://github.com/rapidsai/jupyterlab-nvdashboard/assets/5832902/eeb6f36d-6561-4074-9bb0-550701c9a146) |