### PR TITLE
enforce wheel size limits, README formatting in CI

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -38,6 +38,8 @@ python -m pip install build
 # Build the Python package
 python -m build -s -w
 
+ci/validate_wheel.sh dist
+
 rapids-logger "Uploading JupyterLab NVDashboard wheels to S3"
 # Upload Python wheels to S3
 RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+wheel_dir_relative_path=$1
+
+rapids-logger "validate packages with 'pydistcheck'"
+
+pydistcheck \
+    --inspect \
+    "$(echo ${wheel_dir_relative_path}/*.whl)"
+
+rapids-logger "validate packages with 'twine'"
+
+twine check \
+    --strict \
+    "$(echo ${wheel_dir_relative_path}/*.whl)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,11 @@ force-exclude = '''
     package.json
 )/
 '''
+
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+
+# PyPI limit is 100 MiB, fail CI before we get too close to that
+max_allowed_size_compressed = '75M'


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/110

Proposes adding 2 types of validation on wheels in CI, to ensure we continue to produce wheels that are suitable for PyPI.

* checks on wheel size (compressed),
  - *to be sure they're under PyPI limits*
  - *and to prompt discussion on PRs that significantly increase wheel sizes*
* checks on README formatting
  - *to ensure they'll render properly as the PyPI project homepages*
  - *e.g. like how https://github.com/scikit-learn/scikit-learn/blob/main/README.rst becomes https://pypi.org/project/scikit-learn/*