### PR TITLE
Download build artifacts from Github for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       script: ci/build_wheel.sh
       # Package is pure Python and only ever requires one build.
       matrix_filter: 'map(select((.LINUX_VER | test("centos")|not))) | sort_by((.PY_VER | split(".") | map(tonumber))) | [.[-1] + {ARCH: "amd64"}]'
-      wheel-name: jupyterlab-nvdashboard
+      package-name: jupyterlab-nvdashboard
       package-type: python
       pure-wheel: true
       append-cuda-suffix: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,7 +47,7 @@ jobs:
       # This selects the latest supported Python + CUDA
       matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"
-      wheel-name: jupyterlab-nvdashboard
+      package-name: jupyterlab-nvdashboard
       package-type: python
       pure-wheel: true
       append-cuda-suffix: false

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -19,7 +19,7 @@ conda activate test
 set -u
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-print-env
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,10 +7,10 @@ set -eou pipefail
 package_name="jupyterlab-nvdashboard"
 
 rapids-logger "Downloading artifacts from previous jobs"
-RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 ./dist
+WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` required for pip
-python -m pip install $(echo ./dist/jupyterlab_nvdashboard*.whl)[test]
+python -m pip install $(echo "${WHEELHOUSE}"/jupyterlab_nvdashboard*.whl)[test]
 
 rapids-logger "Check GPU usage"
 nvidia-smi


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/build-infra/issues/237)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 