### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       # Package is pure Python and only ever requires one build.
       matrix_filter: 'map(select(.ARCH == "amd64" and (.LINUX_VER | test("centos")|not))) | sort_by(.PY_VER | split(".") | map(tonumber)) | [.[-1]]'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,7 @@ jobs:
       build_type: pull-request
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      script: ci/build_python.sh
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
@@ -38,6 +39,7 @@ jobs:
       build_type: pull-request
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      script: ci/test_python.sh
   wheel-build:
     needs: checks
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         args: ['--config=.flake8']
         files: jupyterlab_nvdashboard/.*$
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.14.0
+    rev: v1.18.1
     hooks:
       - id: rapids-dependency-file-generator
         args: ['--clean']

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -10,6 +10,7 @@ package_name="jupyterlab-nvdashboard"
 # Configure sccache and set the date string
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-init-pip
 
 rapids-logger "Install Node.js required for building the extension front-end"
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,6 +3,8 @@
 
 set -eou pipefail
 
+source rapids-init-pip
+
 # Set the package name
 package_name="jupyterlab-nvdashboard"
 


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`

Also updates `pre-commit` config to the latest `rapids-dependency-file-generator` version. It was a few versions behind, thought it'd be ok to bundle that update in with the rest of these changes.