### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # default (to be overridden by any matches in later lines below)
-*                        @jupyterlab-nvdashboard-write
+*                        @rapidsai/jupyterlab-nvdashboard-write
 
 # CI code owners
 .flake8

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 *                        @rapidsai/jupyterlab-nvdashboard-write
 
 # CI code owners
-.flake8
+.flake8                  @rapidsai/ci-codeowners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# default (to be overridden by any matches in later lines below)
+*                        @jupyterlab-nvdashboard-write
+
+# CI code owners
+.flake8
+/.github/                @rapidsai/ci-codeowners
+/ci/                     @rapidsai/ci-codeowners
+
+# packaging code owners
+/.pre-commit-config.yaml @rapidsai/packaging-codeowners
+/conda/                  @rapidsai/packaging-codeowners
+dependencies.yaml        @rapidsai/packaging-codeowners
+/build.sh                @rapidsai/packaging-codeowners
+pyproject.toml           @rapidsai/packaging-codeowners
+setup.py                 @rapidsai/packaging-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 *                        @rapidsai/jupyterlab-nvdashboard-write
 
 # CI code owners
-.flake8                  @rapidsai/ci-codeowners
+.flake8                  @rapidsai/ci-codeowners @rapidsai/packaging-codeowners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 

--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,4 +1,5 @@
 # This file controls which features from the `ops-bot` repository below are enabled.
 # - https://github.com/rapidsai/ops-bot
 
+auto_merger: true
 forward_merger: true


### PR DESCRIPTION
Proposes adding a `CODEOWNERS` file to automatically assign reviews, and using it to split reviewing responsibility as follows:

* CI changes: https://github.com/orgs/rapidsai/teams/ci-codeowners
* packaging changes: https://github.com/orgs/rapidsai/teams/packaging-codeowners
* all other changes: https://github.com/orgs/rapidsai/teams/jupyterlab-nvdashboard-write

The main goal of this change is to reduce the reviewing burden on this library's main developers for RAPIDS-wide packaging changes like #236 .