### PR TITLE
add shellcheck to pre-commit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # CI code owners
 .flake8                  @rapidsai/ci-codeowners @rapidsai/packaging-codeowners
 /.github/                @rapidsai/ci-codeowners
+.shellcheckrc            @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 
 # packaging code owners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ repos:
       - id: flake8
         args: ['--config=.flake8']
         files: jupyterlab_nvdashboard/.*$
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.18.1
     hooks:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Disable file checks (otherwise every use of `gha-tools` will get flagged)
+disable=SC1091

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -4,9 +4,6 @@
 # Exit script if any command fails
 set -euo pipefail
 
-# Set the package name
-package_name="jupyterlab-nvdashboard"
-
 # Configure sccache and set the date string
 source rapids-configure-sccache
 source rapids-date-string

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -12,21 +12,12 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
-
-#Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
-NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
 echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 jq --indent 4 -e --arg tag "$NEXT_FULL_TAG" '.version=$tag' package.json > package.json.tmp

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -12,7 +12,8 @@ rapids-logger "Downloading artifacts from previous jobs"
 WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` required for pip
-python -m pip install $(echo "${WHEELHOUSE}"/jupyterlab_nvdashboard*.whl)[test]
+python -m pip install \
+    "$(echo "${WHEELHOUSE}"/jupyterlab_nvdashboard*.whl)[test]"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -9,10 +9,10 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these warnings:

```text
SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).
SC2086 (info): Double quote to prevent globbing and word splitting.
SC1091 (info): Not following: rapids-init-pip was not specified as input (see shellcheck -x).
SC1091 (info): Not following: /opt/conda/etc/profile.d/conda.sh was not specified as input (see shellcheck -x).
SC2034 (warning): NEXT_SHORT_TAG appears unused. Verify use (or export if used externally).
SC2034 (warning): CURRENT_SHORT_TAG appears unused. Verify use (or export if used externally).
SC2034 (warning): package_name appears unused. Verify use (or export if used externally).
```

Also updates all other hooks with `pre-commit autoupdate`.