### PR TITLE
run tests on CUDA 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   conda-python-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
   upload-conda:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -55,7 +55,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -71,7 +71,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,8 +37,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects "one job per CUDA major version, and the latest Python version within each of those" (indifferent between amd64 and arm64)
-      matrix_filter: 'group_by([(.CUDA_VER|split(".")|map(tonumber))]) | map(sort_by(.PY_VER|split(".")|map(tonumber)) | .[-1])'
+      # This selects "ARCH=amd64 + the latest supported Python".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
       script: ci/test_python.sh
   wheel-build:
     needs: checks
@@ -59,6 +59,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects "one job per CUDA major version, and the latest Python version within each of those" (indifferent between amd64 and arm64)
-      matrix_filter: 'group_by([(.CUDA_VER|split(".")|map(tonumber))]) | map(sort_by(.PY_VER|split(".")|map(tonumber)) | .[-1])'
+      # This selects the latest supported Python
+      matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/test_wheel.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,14 +18,14 @@ jobs:
       - wheel-build
       - wheel-tests
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda13.0
   checks:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda13.0
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: pull-request
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
@@ -34,16 +34,16 @@ jobs:
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      # This selects "ARCH=amd64 + the latest supported Python".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)))]) | [.]
       script: ci/test_python.sh
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda13.0
     with:
       build_type: pull-request
       # This selects the latest supported Python + CUDA
@@ -56,9 +56,9 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects the latest supported Python + CUDA
-      matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      # This selects the latest supported Python
+      matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/test_wheel.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,8 +37,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects "ARCH=amd64 + the latest supported Python".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
+      # This selects "one job per CUDA major version, and the latest Python version within each of those" (indifferent between amd64 and arm64)
+      matrix_filter: 'group_by([(.CUDA_VER|split(".")|map(tonumber))]) | map(sort_by(.PY_VER|split(".")|map(tonumber)) | .[-1])'
       script: ci/test_python.sh
   wheel-build:
     needs: checks
@@ -59,6 +59,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda13.0
     with:
       build_type: pull-request
-      # This selects the latest supported Python
-      matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
+      # This selects "one job per CUDA major version, and the latest Python version within each of those" (indifferent between amd64 and arm64)
+      matrix_filter: 'group_by([(.CUDA_VER|split(".")|map(tonumber))]) | map(sort_by(.PY_VER|split(".")|map(tonumber)) | .[-1])'
       script: "ci/test_wheel.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
     with:
       build_type: pull-request
       # This selects "ARCH=amd64 + the latest supported Python".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)))]) | [.]
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber))]) | [.]
       script: ci/test_python.sh
   wheel-build:
     needs: checks

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,7 +12,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda13.0
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.18.1
+    rev: v1.19.2
     hooks:
       - id: rapids-dependency-file-generator
         args: ['--clean']


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

Proposes running tests in CUDA 13 environments. `jupyterlab-nvdashboard` is pure-Python and shouldn't be dependent on CUDA version, but doing this will give us higher confidence that its dependencies like `pynvml` are working correctly across both major CUDA versions supported by RAPIDS.

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda13.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/413

A future round of PRs will revert that back to `branch-25.10`, once all of RAPIDS supports CUDA 13.