### PR TITLE
remove setup.py, remove license classifier, update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,24 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.12.0
     hooks:
       - id: black
         files: jupyterlab_nvdashboard/.*
         # Explicitly specify the pyproject.toml at the repo root, not per-project.
         args: ['--config', 'pyproject.toml']
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: ['--config=.flake8']
         files: jupyterlab_nvdashboard/.*$
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.19.2
+    rev: v1.20.2
     hooks:
       - id: rapids-dependency-file-generator
         args: ['--clean']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyterlab_nvdashboard"
 readme = "README.md"
-license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyterlab_nvdashboard"
 readme = "README.md"
+license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
 ]
@@ -22,7 +23,6 @@ classifiers = [
     "Framework :: Jupyter :: JupyterLab :: 4",
     "Framework :: Jupyter :: JupyterLab :: Extensions",
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/152

* removes `setup.py` (no longer needed as this project switched to `hatchling` in #169)
* removes license classifiers ([deprecated as of PEP 639](https://peps.python.org/pep-0639/#deprecate-license-classifiers))
* updates `pre-commit` hooks to their latest versions