### PR TITLE
tighten wheel size limits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,5 +23,9 @@ repos:
     hooks:
       - id: rapids-dependency-file-generator
         args: ['--clean']
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v1.3.3
+    hooks:
+      - id: verify-pyproject-license
 default_language_version:
   python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,5 @@ repos:
     hooks:
       - id: rapids-dependency-file-generator
         args: ['--clean']
-  - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.3
-    hooks:
-      - id: verify-pyproject-license
 default_language_version:
   python: python3

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 # Configure sccache and set the date string
 source rapids-configure-sccache
 source rapids-date-string
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 rapids-logger "Install Node.js required for building the extension front-end"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyterlab_nvdashboard"
 readme = "README.md"
+license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
 ]
@@ -121,5 +122,5 @@ select = [
     "distro-too-large-compressed",
 ]
 
-# PyPI limit is 100 MiB, fail CI before we get too close to that
-max_allowed_size_compressed = '75M'
+# PyPI hard limit is 1GiB, but try to keep this as small as possible
+max_allowed_size_compressed = '10Mi'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyterlab_nvdashboard"
 readme = "README.md"
-license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
 ]


### PR DESCRIPTION
## Description

Proposes a batch of miscellaneous build / packaging / CI changes.

## Changes

### Tightens wheel size limits

Contributes to https://github.com/rapidsai/build-planning/issues/219

To ensure surprising package-size growth is caught in CI, this PR tightens the limits in the following ways:

* setting all limits to `{compressed_size} + 10Mi`, rounded to the nearest 5Mi

### Enforces PEP 639 license metadata in `pyproject.toml`

Contributes to https://github.com/rapidsai/pre-commit-hooks/issues/95
