### PR TITLE
remove pip.conf migration code in CI scripts

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,8 +7,6 @@ set -euo pipefail
 # Configure sccache and set the date string
 source rapids-configure-sccache
 source rapids-date-string
-RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
-export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 rapids-logger "Install Node.js required for building the extension front-end"


### PR DESCRIPTION
## Description

Follow-up to changes for https://github.com/rapidsai/build-planning/issues/241

* removes `rapids-init-pip` feature flags now that those have become the default behavior (https://github.com/rapidsai/gha-tools/pull/242)