### PR TITLE
drop reliance on 'nvidia' conda channel

### DIFF
--- a/conda/environments/all_arch-any.yaml
+++ b/conda/environments/all_arch-any.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - jupyterlab>=4.0.0
 - nodejs=18

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -46,7 +46,6 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - conda-forge
-  - nvidia
 dependencies:
   build_wheels:
     common:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/254

The `nvidia` conda channel should no longer be necessary here.