### PR TITLE
pin yarn in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bundle.*
 lib/
 node_modules/
+package-lock.json
 *.log
 .eslintcache
 .stylelintcache

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -19,7 +19,19 @@ rapids-logger "Run pre-commit checks - Python backend"
 # Run pre-commit checks
 pre-commit run --hook-stage manual --all-files --show-diff-on-failure
 
+# yarn version needs to be consistent between what 'jlpm' wraps and what is declared
+# in 'package.json', so automated dependency updates work as expected
+rapids-logger "checking yarn versions"
+JLPM_VERSION=$(jlpm --version 2>/dev/null)
+PACKAGE_JSON_VERSION=$(jq -r '."packageManager"' < ./package.json | cut -d@ -f2)
+if [[ "${JLPM_VERSION}" != "${PACKAGE_JSON_VERSION}" ]]; then
+  echo "error: yarn version from 'jlpm --version' (${JLPM_VERSION}) and 'packageManager' field in package.json (${PACKAGE_JSON_VERSION}) do not match."
+  exit 1
+fi
+
+
 rapids-logger "eslint:check - TS frontend"
+
 # Run eslint checks
 jlpm install
 jlpm run eslint:check

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
         "style/index.js"
     ],
     "styleModule": "style/index.js",
-    "packageManager": "yarn@4.16.0",
+    "packageManager": "yarn@3.5.0",
     "publishConfig": {
         "access": "public"
     },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "style/index.js"
     ],
     "styleModule": "style/index.js",
+    "packageManager": "yarn@4.16.0",
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
We've been fighting `dependabot` over the content of a patch:

* https://github.com/rapidsai/jupyterlab-nvdashboard/pull/273/changes/5c199b1e8cc29ae2dcd7cdd26b257011369b438c
* https://github.com/rapidsai/jupyterlab-nvdashboard/pull/274#issuecomment-4653989389

Seeing failures here on dependabot PRs:

https://github.com/rapidsai/jupyterlab-nvdashboard/blob/216c60a2e71aada31bd5ec699818489ee01617d5/ci/check_style.sh#L22-L25

I think the root cause might be that `dependabot` is using a different version of `yarn` to generate the `yarn.lock` changes.

This tries to fix that by pinning `yarn` here.

## Notes for Reviewers

### Why I think this might work

`jupyterlab-git` does this ([code link](https://github.com/jupyterlab/jupyterlab-git/blob/87024b9c122897aa7f471e0a2b44ecfde54adc80/package.json#L58)) and uses `dependabot` to update `yarn.lock` (https://github.com/jupyterlab/jupyterlab-git/commits/main/yarn.lock)

I haven't found direct docs or code saying that `dependabot` supports reading this, but it seems like it's a standard other project use. More evidence:

* https://github.com/dependabot/dependabot-core/issues/4830
* https://github.com/nodejs/corepack#when-authoring-packages

Couldn't hurt to try 🤷🏻 