### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,8 +42,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
-      # Package is pure Python and only ever requires one build.
-      matrix_filter: 'map(select(.ARCH == "amd64" and (.LINUX_VER | test("centos")|not))) | sort_by(.PY_VER | split(".") | map(tonumber)) | [.[-1]]'
+      pure-conda: true
     permissions:
       actions: read
       contents: read
@@ -74,10 +73,11 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
-      # Package is pure Python and only ever requires one build.
-      matrix_filter: 'map(select((.LINUX_VER | test("centos")|not))) | sort_by((.PY_VER | split(".") | map(tonumber))) | [.[-1] + {ARCH: "amd64"}]'
       package-name: jupyterlab-nvdashboard
       package-type: python
+      # Package is pure Python and only ever requires one build.
+      matrix_filter: 'map(select((.LINUX_VER | test("centos")|not))) | sort_by((.PY_VER | split(".") | map(tonumber))) | [.[-1] + {ARCH: "amd64"}]'
+      # pure-wheel is technically redundant here (and not sufficient on its own as it will build one wheel per major cuda version)
       pure-wheel: true
       append-cuda-suffix: false
     permissions:
@@ -97,6 +97,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: jupyterlab-nvdashboard
       publish_to_pypi: true
+      publish-wheel-search-key: jupyterlab-nvdashboard_wheel_python_jupyterlab-nvdashboard
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,9 +47,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: ci/build_python.sh
+      pure-conda: true
     permissions:
       actions: read
       contents: read

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -37,3 +37,6 @@ rattler-build build --recipe conda/recipes/jupyterlab-nvdashboard \
 # remove build_cache directory to avoid uploading the entire source tree
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python jupyterlab-nvdashboard jupyterlab-nvdashboard --pure --arch any)"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -37,3 +37,6 @@ python -m pip install build
 python -m build --wheel --outdir "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
 ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python jupyterlab-nvdashboard jupyterlab-nvdashboard --pure --arch any)"
+export RAPIDS_PACKAGE_NAME

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -euo pipefail
@@ -20,7 +20,7 @@ conda activate test
 set -u
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python jupyterlab-nvdashboard jupyterlab-nvdashboard --pure --arch any)")
 
 rapids-print-env
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -eou pipefail
 
 source rapids-init-pip
 
-# Set the package name
-package_name="jupyterlab-nvdashboard"
-
 rapids-logger "Downloading artifacts from previous jobs"
-WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
+WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python jupyterlab-nvdashboard jupyterlab-nvdashboard --pure --arch any)")
 
 # echo to expand wildcard before adding `[extra]` required for pip
 python -m pip install \


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270