### PR TITLE
bump version on package.json to 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-nvdashboard",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "A JupyterLab extension for displaying GPU usage dashboards",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Since we have 0.14.0 released now, I'm following the release process of bumping the version on package.json