### PR TITLE
fix tagging instructions in release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ To cut a new release:
 
 ```shell
 git checkout main
-TAG="$(jq -r '."version"' < ./package.json)a"
+TAG="v$(jq -r '."version"' < ./package.json)a"
 git tag "${TAG}"
 git push upstream "${TAG}"
 ```


### PR DESCRIPTION
In #283 CI, I noticed packages were getting versions like `0.14.0rc4`.

Looks like that was because the tag pushed after #282 was `0.15.0a`, not `v0.15.0a`. I think the `v` is significant for RAPIDS scripts:

https://github.com/rapidsai/gha-tools/blob/b6f0ce15b1f35c8ab1572c3812bd12555473119f/tools/rapids-generate-version#L6

This fixes the instructions.

I've manually update the tag to `v0.15.0a`, so we should also get nightlies with the correct versions now.