### PR TITLE
dependabot: fix grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,3 @@ updates:
     groups:
       npm-and-yarn:
         applies-to: security-updates
-        patterns:
-          - "*"


### PR DESCRIPTION
We attempted to have `dependabot` group all updates into a single PR in #267 , but seems like it isn't working: https://github.com/rapidsai/jupyterlab-nvdashboard/pull/289#issuecomment-4783484002

In https://github.com/dependabot/dependabot-core/issues/13919, there's a suggestion that removing `patterns: ["*"]` from the config might help.

Let's try it.