### PR TITLE
fix dependabot grouping (again)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,11 @@ updates:
     cooldown:
       default-days: 15
     groups:
+      # 'patterns' is omitted here because it breaks grouping in some situations,
+      # see https://github.com/dependabot/dependabot-core/issues/13919
       npm-and-yarn:
         applies-to: security-updates
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
See https://github.com/rapidsai/jupyterlab-nvdashboard/pull/289#issuecomment-4793368337

#290 made this project's dependabot configuration invalid. Still not really clear to me what needs to change to enable grouping to work the way we want, but I'm hoping that adding at least one more specific thing to the `npm-and-yarn` rule will help.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups-- is ambiguous about how this is supposed to be formatted.