### PR TITLE
ensure nightly builds always produce new packages (conda-only)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,10 +36,12 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
@@ -67,10 +69,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,12 +69,10 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
-    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,8 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,12 +90,11 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
-    needs: [build-details, checks]
+    needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
-      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       # This selects the latest supported Python + CUDA
       matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,6 +28,8 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   checks:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   pr-builder:
     needs:
+      - build-details
       - checks
       - conda-python-build
       - conda-python-tests
@@ -45,11 +46,12 @@ jobs:
       packages: read
       pull-requests: read
   conda-python-build:
-    needs: checks
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       pure-conda: true
     permissions:
@@ -88,11 +90,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
-    needs: checks
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       # This selects the latest supported Python + CUDA
       matrix_filter: max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -8,7 +8,7 @@
 # Exit script if any command fails
 set -euo pipefail
 
-source rapids-date-string
+source rapids-datetime-string
 
 rapids-print-env
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 # Configure sccache and set the date string
 source rapids-configure-sccache
-source rapids-date-string
+source rapids-datetime-string
 source rapids-init-pip
 
 rapids-logger "Install Node.js required for building the extension front-end"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -20,7 +20,10 @@ export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm install 22 && nvm use 22
 
 # Generate version and replace any letter with a hyphen (hatch-nodejs-version does not like pre-release versions)
-version=$(rapids-generate-version)
+version=$(
+    RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+        rapids-generate-version
+)
 node_version=$(echo "$version" | sed 's/[a-zA-Z]/-\0/' | sed 's/^-//')
 
 # Update the version field in package.json

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 # Configure sccache and set the date string
 source rapids-configure-sccache
-source rapids-datetime-string
 source rapids-init-pip
 
 rapids-logger "Install Node.js required for building the extension front-end"
@@ -20,10 +19,7 @@ export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm install 22 && nvm use 22
 
 # Generate version and replace any letter with a hyphen (hatch-nodejs-version does not like pre-release versions)
-version=$(
-    RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
-        rapids-generate-version
-)
+version=$(rapids-generate-version)
 node_version=$(echo "$version" | sed 's/[a-zA-Z]/-\0/' | sed 's/^-//')
 
 # Update the version field in package.json

--- a/conda/recipes/jupyterlab-nvdashboard/recipe.yaml
+++ b/conda/recipes/jupyterlab-nvdashboard/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
@@ -18,7 +18,7 @@ source:
 
 build:
   noarch: python
-  string: py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}
+  string: py${{ py_buildstring }}_${{ datetime_string }}_${{ head_rev }}
   script:
     content: |
       python -m pip install . -vv


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

* uses the new patterns for versioning nightly packages (see https://github.com/rapidsai/shared-workflows/pull/603), to ensure they're always uploaded on new builds.

For conda:

```text
# before
26.10.0a55[build=cuda12_260803_9da146ef]

# after
26.10.0a55[build=cuda12_260803200854_9da146ef]
```

## Notes for Reviewers

### How I tested this

See https://github.com/rapidsai/cugraph-gnn/pull/508
